### PR TITLE
fix: Restore basePath configuration for BetterAuth

### DIFF
--- a/lib/auth-client.ts
+++ b/lib/auth-client.ts
@@ -5,5 +5,6 @@ export const authClient = createAuthClient({
   baseURL: typeof window !== "undefined" 
     ? window.location.origin 
     : (process.env.NEXT_PUBLIC_AUTH_URL || "http://localhost:3000"),
+  basePath: "/api/auth",
   plugins: [genericOAuthClient()],
 });

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -12,6 +12,7 @@ export const auth = betterAuth({
     idleTimeoutMillis: 30000, // Close idle clients after 30 seconds
     connectionTimeoutMillis: 2000, // Return an error after 2 seconds if connection cannot be established
   }),
+  basePath: "/api/auth",
   baseURL: getBaseUrl(),
   emailAndPassword: {
     enabled: true


### PR DESCRIPTION
## Summary
- Restored the `basePath: "/api/auth"` configuration that was accidentally removed in commit 2660351
- Added basePath to both server (`lib/auth.ts`) and client (`lib/auth-client.ts`) configurations
- This fixes the OAuth metadata discovery failure in MCP Inspector

## Problem
The previous commit removed the basePath configuration, causing OAuth discovery endpoints to return incorrect URLs. The metadata was referencing `/api/auth/mcp/*` endpoints that no longer existed after the basePath removal.

## Solution
Restored the basePath configuration to ensure OAuth endpoints are correctly mapped under `/api/auth/`.

## Test plan
- [ ] Deploy to Vercel
- [ ] Test OAuth discovery with MCP Inspector at `https://mcp-betterauth-nextjs.vercel.app/api/mcp`
- [ ] Verify OAuth metadata endpoints return correct URLs
- [ ] Confirm MCP Inspector can connect without "Failed to discover OAuth metadata" error

🤖 Generated with [Claude Code](https://claude.ai/code)