### PR TITLE
fix: Replace startNewTrace with forceTransaction to fix 500 error

### DIFF
--- a/lib/tools/register-tool.ts
+++ b/lib/tools/register-tool.ts
@@ -51,16 +51,17 @@ export function registerTool(
     schema,
     async (args: any) => {
       // Start a new trace for each tool call
-      return await Sentry.startNewTrace(async () => {
-        return await Sentry.startSpan(
-          {
-            name: `mcp.tool/${name}`,
-            attributes: {
-              "mcp.tool.name": name,
-              ...extractMcpParameters(args),
-            },
+      return await Sentry.startSpan(
+        {
+          name: `mcp.tool/${name}`,
+          op: "mcp.tool",
+          forceTransaction: true, // This creates a new transaction/trace
+          attributes: {
+            "mcp.tool.name": name,
+            ...extractMcpParameters(args),
           },
-          async (span) => {
+        },
+        async (span) => {
             // Use withScope to isolate context changes to this specific tool execution
             return await Sentry.withScope(async (scope) => {
               // Get the context from the server's stored session
@@ -107,9 +108,8 @@ export function registerTool(
               }
               // No need for finally block - scope is automatically cleaned up
             });
-          }
-        );
-      });
+        }
+      );
     }
   );
 }


### PR DESCRIPTION
## Problem
After merging the Sentry tracing PR, the MCP server returns a 500 error when calling any tool:
```
Error: Error POSTing to endpoint (HTTP 500): {"error": {"code": "500", "message": "A server error has occurred"}}
```

## Root Cause
The `Sentry.startNewTrace()` API doesn't exist in the `@sentry/nextjs` SDK. This causes a runtime error when any MCP tool is invoked.

## Solution
- Replace `startNewTrace()` with `forceTransaction: true` option on `startSpan()`
- This achieves the same goal (creating a new trace) using the correct API
- Added `op: "mcp.tool"` for better trace categorization

## Testing
- [x] TypeScript compiles without errors
- [x] Linting passes
- [ ] MCP tools work without 500 errors
- [ ] Traces appear correctly in Sentry dashboard

This is a critical fix that needs to be deployed ASAP to restore MCP functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)