### PR TITLE
fix: Resolve MCP 500 errors by simplifying Sentry integration

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -19,10 +19,8 @@ Sentry.init({
 
   // Add integrations for better tracing
   integrations: [
-    // HTTP integration for automatic trace propagation
-    Sentry.httpIntegration({
-      breadcrumbs: true,
-    }),
+    // Note: httpIntegration is not available in @sentry/nextjs v9
+    // It's included by default in the Next.js SDK
   ],
 
   // Propagate traces to all external APIs using wildcard

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -18,10 +18,8 @@ Sentry.init({
 
   // Add integrations for better tracing
   integrations: [
-    // HTTP integration for automatic trace propagation
-    Sentry.httpIntegration({
-      breadcrumbs: true,
-    }),
+    // Note: httpIntegration is not available in @sentry/nextjs v9
+    // It's included by default in the Next.js SDK
   ],
 
   // Propagate traces to all external APIs using wildcard


### PR DESCRIPTION
## Problem
After merging the Sentry tracing PR (#9), the MCP server was returning 500 errors when calling any tool:
```
Error: Error POSTing to endpoint (HTTP 500): {"error": {"code": "500", "message": "A server error has occurred"}}
```

## Root Cause
Multiple issues with the Sentry integration:
1. `Sentry.startNewTrace()` API doesn't exist in `@sentry/nextjs` v9
2. `httpIntegration` is not exported from `@sentry/nextjs` v9 (it's included by default)
3. Complex span nesting was causing runtime errors

## Solution
Simplified the Sentry integration to fix the 500 errors while maintaining error tracking:

### Changes Made:
1. **Removed all `startSpan` calls** that were causing runtime errors
2. **Kept essential Sentry functionality**:
   - Error tracking with `withScope` for context isolation
   - Breadcrumbs for tracking tool execution  
   - User context and session data
   - Try-catch blocks to gracefully handle any Sentry failures

3. **Fixed configuration issues**:
   - Removed `httpIntegration` from integrations array (not available in v9)
   - Added comments explaining the limitations

### Code Changes:
- `lib/tools/register-tool.ts`: Simplified to use breadcrumbs instead of spans
- `lib/tools/create-provider-tool.ts`: Removed span wrapping, kept breadcrumbs
- `lib/external-api-helpers/simplified-api-client.ts`: Removed all span instrumentation
- `sentry.server.config.ts` & `sentry.edge.config.ts`: Removed httpIntegration

## Testing
- [x] TypeScript compiles without errors
- [x] Linting passes
- [x] Deployed to Vercel successfully
- [ ] MCP tools work without 500 errors
- [ ] Basic error tracking still functions in Sentry

## Deployment
Already deployed to: https://improve-sentry-monitoring-qsu7j6clq-lloyd-vickerys-projects.vercel.app

This is a critical fix that restores MCP functionality. Once confirmed working, we can gradually reintroduce more advanced tracing features using the correct Sentry v9 APIs.

🤖 Generated with [Claude Code](https://claude.ai/code)