### PR TITLE
test: OAuth hub flow testing utilities

### DIFF
--- a/app/api/test/env-check/route.ts
+++ b/app/api/test/env-check/route.ts
@@ -1,0 +1,67 @@
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const envCheck = {
+    oauth: {
+      microsoft: {
+        clientId: !!process.env.MICROSOFT_CLIENT_ID,
+        clientSecret: !!process.env.MICROSOFT_CLIENT_SECRET,
+        tenantId: process.env.MICROSOFT_TENANT_ID || 'common',
+      },
+    },
+    hub: {
+      authHubUrl: process.env.AUTH_HUB_URL || null,
+      publicAuthHubUrl: process.env.NEXT_PUBLIC_AUTH_HUB_URL || null,
+      stateSecret: !!process.env.STATE_SECRET,
+      allowedDomains: process.env.ALLOWED_REDIRECT_DOMAINS || null,
+    },
+    deployment: {
+      vercelUrl: process.env.VERCEL_URL || null,
+      nodeEnv: process.env.NODE_ENV,
+      authUrl: process.env.AUTH_URL || null,
+    },
+    database: {
+      configured: !!process.env.DATABASE_URL,
+    },
+    auth: {
+      betterAuthSecret: !!process.env.BETTER_AUTH_SECRET,
+    },
+  };
+
+  // Check if hub pattern is properly configured
+  const hubPatternReady = !!(
+    envCheck.hub.authHubUrl &&
+    envCheck.hub.publicAuthHubUrl &&
+    envCheck.hub.stateSecret
+  );
+
+  // Add recommendations
+  const recommendations = [];
+  
+  if (!hubPatternReady && process.env.VERCEL_URL?.includes('.vercel.app')) {
+    recommendations.push('Configure AUTH_HUB_URL, NEXT_PUBLIC_AUTH_HUB_URL, and STATE_SECRET for OAuth on preview URLs');
+  }
+  
+  if (!envCheck.oauth.microsoft.clientId || !envCheck.oauth.microsoft.clientSecret) {
+    recommendations.push('Configure MICROSOFT_CLIENT_ID and MICROSOFT_CLIENT_SECRET');
+  }
+  
+  if (!envCheck.auth.betterAuthSecret) {
+    recommendations.push('Configure BETTER_AUTH_SECRET for secure sessions');
+  }
+
+  return NextResponse.json({
+    timestamp: new Date().toISOString(),
+    environment: envCheck,
+    status: {
+      hubPatternReady,
+      oauthConfigured: envCheck.oauth.microsoft.clientId && envCheck.oauth.microsoft.clientSecret,
+      isPreview: !!process.env.VERCEL_URL?.includes('.vercel.app'),
+    },
+    recommendations,
+  }, {
+    headers: {
+      'Cache-Control': 'no-store',
+    },
+  });
+}

--- a/app/connections/page.tsx
+++ b/app/connections/page.tsx
@@ -255,6 +255,18 @@ export default function Connections() {
             authentication, it will use the connected account associated with your Microsoft login.
           </p>
         </div>
+
+        {/* Development/Testing Link */}
+        {process.env.NODE_ENV === 'development' && (
+          <div className="mt-4 text-center">
+            <a 
+              href="/test-oauth" 
+              className="text-sm text-blue-600 hover:text-blue-800 underline"
+            >
+              Test OAuth Flow →
+            </a>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/test-oauth/page.tsx
+++ b/app/test-oauth/page.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { authClient } from "@/lib/auth-client";
+
+export default function TestOAuth() {
+  const [environment, setEnvironment] = useState<{
+    authHubUrl?: string;
+    currentUrl: string;
+    isPreview: boolean;
+    isProduction: boolean;
+    isLocal: boolean;
+  }>({
+    currentUrl: '',
+    isPreview: false,
+    isProduction: false,
+    isLocal: false,
+  });
+  
+  const [oauthFlow, setOauthFlow] = useState<{
+    redirectUri?: string;
+    stateGenerated?: boolean;
+    callbackExpected?: string;
+  }>({});
+  
+  const [session, setSession] = useState<any>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    // Check environment
+    const url = window.location.origin;
+    setEnvironment({
+      authHubUrl: process.env.NEXT_PUBLIC_AUTH_HUB_URL,
+      currentUrl: url,
+      isPreview: url.includes('.vercel.app') && !url.includes('mcp-betterauth-nextjs.vercel.app'),
+      isProduction: url === process.env.NEXT_PUBLIC_AUTH_HUB_URL,
+      isLocal: url.includes('localhost'),
+    });
+
+    // Check session
+    checkSession();
+  }, []);
+
+  const checkSession = async () => {
+    try {
+      const session = await authClient.getSession();
+      setSession(session);
+    } catch (error) {
+      console.error('Session check failed:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const testOAuthFlow = async () => {
+    // Determine expected flow
+    if (process.env.NEXT_PUBLIC_AUTH_HUB_URL) {
+      setOauthFlow({
+        redirectUri: `${process.env.NEXT_PUBLIC_AUTH_HUB_URL}/api/auth/callback/microsoft`,
+        stateGenerated: true,
+        callbackExpected: `${window.location.origin}/api/auth/session/handoff`,
+      });
+    } else {
+      setOauthFlow({
+        redirectUri: `${window.location.origin}/api/auth/callback/microsoft`,
+        stateGenerated: false,
+        callbackExpected: 'Direct callback to current domain',
+      });
+    }
+
+    // Initiate OAuth
+    window.location.href = `/api/auth/microsoft/initiate?callbackURL=/test-oauth`;
+  };
+
+  const signOut = async () => {
+    await authClient.signOut();
+    window.location.reload();
+  };
+
+  return (
+    <div className="container mx-auto p-8 max-w-4xl">
+      <h1 className="text-3xl font-bold mb-8">OAuth Hub Flow Test</h1>
+      
+      {/* Environment Info */}
+      <div className="bg-gray-100 p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold mb-4">Environment Information</h2>
+        <dl className="space-y-2">
+          <div className="flex">
+            <dt className="font-medium w-48">Current URL:</dt>
+            <dd className="text-blue-600">{environment.currentUrl}</dd>
+          </div>
+          <div className="flex">
+            <dt className="font-medium w-48">Environment Type:</dt>
+            <dd>
+              {environment.isLocal && <span className="px-2 py-1 bg-green-100 text-green-800 rounded">Local</span>}
+              {environment.isPreview && <span className="px-2 py-1 bg-yellow-100 text-yellow-800 rounded">Preview</span>}
+              {environment.isProduction && <span className="px-2 py-1 bg-blue-100 text-blue-800 rounded">Production Hub</span>}
+            </dd>
+          </div>
+          <div className="flex">
+            <dt className="font-medium w-48">AUTH_HUB_URL:</dt>
+            <dd className={environment.authHubUrl ? 'text-green-600' : 'text-red-600'}>
+              {environment.authHubUrl || 'Not configured'}
+            </dd>
+          </div>
+        </dl>
+      </div>
+
+      {/* OAuth Flow Info */}
+      {oauthFlow.redirectUri && (
+        <div className="bg-blue-50 p-6 rounded-lg mb-6">
+          <h2 className="text-xl font-semibold mb-4">Expected OAuth Flow</h2>
+          <dl className="space-y-2">
+            <div className="flex">
+              <dt className="font-medium w-48">Redirect URI:</dt>
+              <dd className="text-sm font-mono">{oauthFlow.redirectUri}</dd>
+            </div>
+            <div className="flex">
+              <dt className="font-medium w-48">State Parameter:</dt>
+              <dd>{oauthFlow.stateGenerated ? '✓ Will be generated with origin' : '✗ Standard flow'}</dd>
+            </div>
+            <div className="flex">
+              <dt className="font-medium w-48">Callback Route:</dt>
+              <dd className="text-sm">{oauthFlow.callbackExpected}</dd>
+            </div>
+          </dl>
+        </div>
+      )}
+
+      {/* Session Info */}
+      <div className="bg-green-50 p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold mb-4">Session Status</h2>
+        {loading ? (
+          <p>Loading...</p>
+        ) : session ? (
+          <div>
+            <p className="text-green-700 font-semibold mb-2">✓ Authenticated</p>
+            <dl className="space-y-2 text-sm">
+              <div className="flex">
+                <dt className="font-medium w-32">User ID:</dt>
+                <dd>{session.user?.id}</dd>
+              </div>
+              <div className="flex">
+                <dt className="font-medium w-32">Email:</dt>
+                <dd>{session.user?.email}</dd>
+              </div>
+              <div className="flex">
+                <dt className="font-medium w-32">Name:</dt>
+                <dd>{session.user?.name}</dd>
+              </div>
+            </dl>
+          </div>
+        ) : (
+          <p className="text-red-700">✗ Not authenticated</p>
+        )}
+      </div>
+
+      {/* Actions */}
+      <div className="flex gap-4">
+        {!session ? (
+          <button
+            onClick={testOAuthFlow}
+            className="px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            Test Microsoft OAuth Flow
+          </button>
+        ) : (
+          <button
+            onClick={signOut}
+            className="px-6 py-3 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors"
+          >
+            Sign Out
+          </button>
+        )}
+      </div>
+
+      {/* Test Instructions */}
+      <div className="mt-8 p-6 bg-yellow-50 rounded-lg">
+        <h2 className="text-xl font-semibold mb-4">Test Instructions</h2>
+        <ol className="list-decimal list-inside space-y-2">
+          <li>Check the environment information above</li>
+          <li>Click &quot;Test Microsoft OAuth Flow&quot; to initiate authentication</li>
+          <li>Watch the URL changes during the flow</li>
+          <li>Verify you&apos;re redirected back to this page after authentication</li>
+          <li>Check that session is established</li>
+        </ol>
+        
+        <div className="mt-4 p-4 bg-white rounded border border-yellow-300">
+          <h3 className="font-semibold mb-2">Expected Flow for Preview URLs:</h3>
+          <ol className="list-decimal list-inside text-sm space-y-1">
+            <li>Click button → Redirect to <code>/api/auth/microsoft/initiate</code></li>
+            <li>Redirect to Microsoft with state parameter</li>
+            <li>After login → Callback to production hub</li>
+            <li>Hub validates state → Redirect to preview <code>/api/auth/session/handoff</code></li>
+            <li>Session established → Redirect back here</li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/docs/OAUTH_TESTING.md
+++ b/docs/OAUTH_TESTING.md
@@ -1,0 +1,134 @@
+# OAuth Hub Testing Guide
+
+This guide helps you test the OAuth hub pattern implementation to ensure it's working correctly on Vercel preview deployments.
+
+## Quick Test
+
+1. **Visit the test page**: Go to `/test-oauth` on your deployment
+2. **Check environment**: Verify the environment information shows correctly
+3. **Test authentication**: Click "Test Microsoft OAuth Flow"
+4. **Verify flow**: Watch the redirects and ensure you return authenticated
+
+## Environment Check
+
+Visit `/api/test/env-check` to see your environment configuration status.
+
+## Test Scenarios
+
+### 1. Local Development (No Hub)
+
+**Setup**:
+- Don't set `AUTH_HUB_URL` in `.env.local`
+- Ensure redirect URI in Azure: `http://localhost:3000/api/auth/callback/microsoft`
+
+**Expected behavior**:
+1. Click sign in → Microsoft OAuth
+2. Callback directly to `localhost:3000`
+3. Session established immediately
+
+### 2. Preview Deployment (With Hub)
+
+**Setup**:
+```env
+# In Vercel environment variables
+AUTH_HUB_URL=https://mcp-betterauth-nextjs.vercel.app
+NEXT_PUBLIC_AUTH_HUB_URL=https://mcp-betterauth-nextjs.vercel.app
+STATE_SECRET=<your-secret>
+```
+
+**Expected behavior**:
+1. From preview URL (e.g., `mcp-preview-123.vercel.app`)
+2. Click sign in → Redirect to `/api/auth/microsoft/initiate`
+3. Redirect to Microsoft with state parameter
+4. After login → Callback to production hub
+5. Hub redirects to preview's `/api/auth/session/handoff`
+6. Session established on preview domain
+
+### 3. Production Hub
+
+**Expected behavior**:
+- Same as local, but handles callbacks for all preview deployments
+- Should process state parameters and redirect appropriately
+
+## Debugging Tips
+
+### Check OAuth Flow
+
+1. **Open browser DevTools Network tab**
+2. **Preserve log** to track redirects
+3. **Look for**:
+   - Initial request to `/api/auth/microsoft/initiate`
+   - Redirect to Microsoft with `state` parameter
+   - Callback to hub URL
+   - Redirect back to preview with token
+   - Final session establishment
+
+### Common Issues
+
+**"Invalid redirect URI" from Microsoft**
+- Ensure Azure AD has: `https://your-hub-domain.vercel.app/api/auth/callback/microsoft`
+- Check `AUTH_HUB_URL` matches exactly
+
+**Session not persisting**
+- Check cookies are being set
+- Verify `BETTER_AUTH_SECRET` is same across deployments
+- Check for HTTPS/secure cookie issues
+
+**State parameter errors**
+- Ensure `STATE_SECRET` is set and consistent
+- Check for URL encoding issues
+- Verify JWT expiration (10 minutes)
+
+## Test Checklist
+
+- [ ] Environment check endpoint shows correct configuration
+- [ ] Test page displays current environment correctly
+- [ ] Local development works without hub
+- [ ] Preview deployment redirects through hub
+- [ ] State parameter is validated correctly
+- [ ] Session persists after redirect
+- [ ] Sign out works properly
+- [ ] Multiple sign in/out cycles work
+- [ ] Works across different preview deployments
+
+## Manual URL Test
+
+You can also test the flow manually:
+
+1. **Generate state** (in browser console):
+```javascript
+// This would normally be done server-side
+const state = btoa(JSON.stringify({
+  origin: window.location.origin,
+  next: '/test-oauth'
+}));
+```
+
+2. **Construct OAuth URL**:
+```
+https://login.microsoftonline.com/common/oauth2/v2.0/authorize?
+client_id=YOUR_CLIENT_ID&
+response_type=code&
+redirect_uri=https://your-hub.vercel.app/api/auth/callback/microsoft&
+scope=openid email profile offline_access&
+state=YOUR_STATE&
+prompt=select_account
+```
+
+3. **Follow the flow** and verify redirects
+
+## Security Verification
+
+1. **Try tampering with state** - Should fail
+2. **Try old state (>10 min)** - Should fail  
+3. **Try redirect to unauthorized domain** - Should fail
+4. **Verify no tokens in URLs** after handoff
+
+## Monitoring
+
+Watch for these in logs:
+- "OAuth state verification failed" - Invalid states
+- "Session handoff failed" - Token issues
+- "Invalid redirect origin" - Security blocks
+
+The test page at `/test-oauth` provides real-time feedback on all these aspects.


### PR DESCRIPTION
## Summary

This PR adds testing utilities to help verify the OAuth hub pattern is working correctly across different deployment environments.

## What's Added

### 1. Test Page (`/test-oauth`)
A comprehensive testing interface that:
- Shows current environment information (local/preview/production)
- Displays OAuth hub configuration status
- Provides a button to test the OAuth flow
- Shows session status after authentication
- Includes step-by-step test instructions

### 2. Environment Check API (`/api/test/env-check`)
An endpoint that returns:
- Current environment variable configuration
- OAuth setup status
- Hub pattern readiness
- Configuration recommendations

### 3. Testing Documentation (`docs/OAUTH_TESTING.md`)
Comprehensive guide covering:
- Quick test procedures
- Test scenarios for each environment type
- Debugging tips and common issues
- Security verification steps
- Manual testing instructions

## How to Test

### Local Development
1. Start the dev server without `AUTH_HUB_URL` set
2. Visit `/test-oauth`
3. Verify it shows "Local" environment
4. Test OAuth - should work with direct callback

### Preview Deployment
1. Deploy this PR to Vercel
2. Ensure these env vars are set in Vercel:
   ```
   AUTH_HUB_URL=https://your-production-domain.vercel.app
   NEXT_PUBLIC_AUTH_HUB_URL=https://your-production-domain.vercel.app
   STATE_SECRET=<your-secret>
   ```
3. Visit `/test-oauth` on the preview URL
4. Verify it shows "Preview" environment with hub URL configured
5. Test OAuth - should redirect through hub and back

### What to Look For
- ✅ Environment correctly detected
- ✅ OAuth flow follows expected path
- ✅ Session established after authentication
- ✅ No errors in console or network tab
- ✅ State parameter included in Microsoft redirect
- ✅ Successful redirect back to preview after auth

## Test Checklist
- [ ] `/test-oauth` page loads correctly
- [ ] `/api/test/env-check` returns valid JSON
- [ ] Local dev works without hub configuration
- [ ] Preview deployment shows hub configuration
- [ ] OAuth flow completes successfully
- [ ] Session persists after redirect
- [ ] Documentation is clear and helpful

🤖 Generated with [Claude Code](https://claude.ai/code)