### PR TITLE
Fix Vercel OAuth state verification error

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -13,8 +13,19 @@ export const auth = betterAuth({
     connectionTimeoutMillis: 2000, // Return an error after 2 seconds if connection cannot be established
   }),
   baseURL: getBaseUrl(),
+  trustHost: true, // Required for Vercel deployment (behind reverse proxy)
   emailAndPassword: {
     enabled: true
+  },
+  // Force secure cookies in production for proper OAuth state handling
+  advanced: {
+    useSecureCookies: process.env.NODE_ENV === 'production',
+    defaultCookieAttributes: {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax' as const,
+      path: '/'
+    }
   },
   socialProviders: {
     microsoft: {
@@ -28,9 +39,6 @@ export const auth = betterAuth({
         ? `${process.env.AUTH_HUB_URL}/api/auth/callback/microsoft`
         : undefined,
       mapProfileToUser: async (profile) => {
-        // Debug logging to see what Microsoft returns
-        console.log("Microsoft profile data:", profile);
-        
         return {
           email: profile.email || profile.mail || profile.userPrincipalName || profile.upn || profile.preferred_username || "",
           name: profile.name || profile.displayName || `${profile.given_name || ""} ${profile.family_name || ""}`.trim() || "",


### PR DESCRIPTION
## Summary
- Fixes the "State Mismatch. Verification not found" error occurring on Vercel production deployment
- Configures Better Auth for proper operation in Vercel's serverless environment

## Problem
When deployed to Vercel, Microsoft OAuth authentication fails with:
```
ERROR [Better Auth]: State Mismatch. Verification not found
```

This occurs because the OAuth state verification fails in the serverless environment due to:
1. Missing reverse proxy configuration
2. Cookie security settings not optimized for production
3. State tokens not being properly stored/retrieved across serverless function invocations

## Solution
1. **Added `trustHost: true`** - Required for Vercel since it runs behind a reverse proxy
2. **Configured secure cookies** - Ensures cookies work properly in production:
   - `httpOnly: true` - Prevents JavaScript access
   - `secure: true` (in production) - HTTPS only
   - `sameSite: 'lax'` - CSRF protection while allowing OAuth flows
   - `path: '/'` - Site-wide availability
3. **Removed debug logging** - Cleaned up console.log that was logging sensitive profile data

## Test Plan
- [x] Verified configuration matches Better Auth best practices for production
- [ ] Deploy to Vercel and test Microsoft OAuth sign-in
- [ ] Verify state verification succeeds
- [ ] Confirm user can complete OAuth flow

🤖 Generated with [Claude Code](https://claude.ai/code)